### PR TITLE
Avoid download busybox container every time

### DIFF
--- a/charts/hasura/templates/deployment.yaml
+++ b/charts/hasura/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         - name: wait-postgres
-          image: busybox
+          image: busybox:1.34.1-uclibc
           command:
             - 'sh'
             - '-c'

--- a/charts/hasura/templates/migrations-metadata-job.yaml
+++ b/charts/hasura/templates/migrations-metadata-job.yaml
@@ -41,7 +41,7 @@ spec:
         {{- end}}
       containers:
         - name: prepare
-          image: busybox
+          image: busybox:1.34.1-uclibc
           command: 
             - sh
             - "-c"
@@ -70,7 +70,7 @@ spec:
               subPath: {{ default "metadata.tar" .Values.metadata.configMap.file }}
             {{- end }}
         - name: wait-hasura
-          image: busybox
+          image: busybox:1.34.1-uclibc
           command:
             - 'sh'
             - '-c'


### PR DESCRIPTION
By using latest, the pull policy is always, meaning recurrent downloads of busybox container,