### PR TITLE
Hardening: explicit jwt secret

### DIFF
--- a/charts/hasura/templates/_helpers.tpl
+++ b/charts/hasura/templates/_helpers.tpl
@@ -15,7 +15,7 @@ Return the jwt secret
 */}}
 {{- define "hasura.jwtSecret" -}}
 {{- if .Values.jwtSecret }}
-{{ include "common.tplvalues.render" (dict "value" .Values.jwtSecret "context" $) }}
+{{- include "common.tplvalues.render" (dict "value" (.Values.jwtSecret|toJson|replace "\\\"" "\""|replace "\"{" "{"|replace "}\"" "}") "context" $) }}
 {{- else }}
   {{- if .Values.jwt.key }}
   {{- include "hasura.generateJwtSecret" . }}

--- a/charts/hasura/templates/_helpers.tpl
+++ b/charts/hasura/templates/_helpers.tpl
@@ -14,25 +14,21 @@ re-generate encoded jwt secret
 Return the jwt secret
 */}}
 {{- define "hasura.jwtSecret" -}}
-{{- if .Values.jwtSecret }}
-{{- include "common.tplvalues.render" (dict "value" (.Values.jwtSecret|toJson|replace "\\\"" "\""|replace "\"{" "{"|replace "}\"" "}") "context" $) }}
+{{- if .Values.jwt.key }}
+{{- include "hasura.generateJwtSecret" . }}
 {{- else }}
-  {{- if .Values.jwt.key }}
-  {{- include "hasura.generateJwtSecret" . }}
-  {{- else }}
-      {{- $secretName := include "hasura.fullname" . }}
-      {{- $secrets := (lookup "v1" "Secret" .Release.Namespace $secretName) }}
-      {{- if $secrets }}
-          {{- $jwtSecret := index $secrets.data "jwt.secret" }}
-          {{- if $jwtSecret }}
-  {{- $jwtSecret | b64dec}}
-          {{- else }}
-  {{- include "hasura.generateJwtSecret" . }}
-          {{- end }}
-      {{- else}}
-  {{- include "hasura.generateJwtSecret" . }}
-      {{- end -}}
-  {{- end -}}
+    {{- $secretName := include "hasura.fullname" . }}
+    {{- $secrets := (lookup "v1" "Secret" .Release.Namespace $secretName) }}
+    {{- if $secrets }}
+        {{- $jwtSecret := index $secrets.data "jwt.secret" }}
+        {{- if $jwtSecret }}
+{{- $jwtSecret | b64dec}}
+        {{- else }}
+{{- include "hasura.generateJwtSecret" . }}
+        {{- end }}
+    {{- else}}
+{{- include "hasura.generateJwtSecret" . }}
+    {{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/hasura/templates/deployment.yaml
+++ b/charts/hasura/templates/deployment.yaml
@@ -109,10 +109,14 @@ spec:
                   name: "{{ $fullname }}"
                   key: adminSecret
             - name: HASURA_GRAPHQL_JWT_SECRET
+              {{- if .Values.jwtSecret }}
+              value: '{{- include "common.tplvalues.render" (dict "value" (.Values.jwtSecret|toJson|replace "\\\"" "\""|replace "\"{" "{"|replace "}\"" "}") "context" $) }}'
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: "{{ $fullname }}"
                   key: jwt.secret
+              {{- end }}
             - name: HASURA_GRAPHQL_UNAUTHORIZED_ROLE
               value: "{{ .Values.unauthorizedRole }}"
             - name: HASURA_GRAPHQL_CORS_DOMAIN


### PR DESCRIPTION
This change will turn an explicitly supplied jwtSecret into an environment variable (not a secret). The value can be specified as string, but also as a more readable yaml object. Making it a "public" value should not be a big issue, as using custom jwtSecret would likely mean that an auth service is being used, so no private bits are present at HASURA_GRAPHQL_JWT_SECRET (at least in our case happens in that way).