### PR TITLE
add db options support

### DIFF
--- a/charts/hasura/Chart.yaml
+++ b/charts/hasura/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 icon: >-
   https://raw.githubusercontent.com/hasura/graphql-engine/3f8013abcb21aa6b732c739e06364a4e9c994a46/assets/brand/hasura_icon_colour.svg
 type: application
-version: 1.1.6
+version: 1.1.7
 appVersion: v2.0.9
 dependencies:
   - name: postgresql

--- a/charts/hasura/templates/postgresql-secrets.yaml
+++ b/charts/hasura/templates/postgresql-secrets.yaml
@@ -3,12 +3,14 @@
 {{- $port := (coalesce .Values.postgresql.service.port .Values.pgClient.external.port 5432) | int -}}
 {{- $host := ternary (printf "%s-postgresql" .Release.Name) .Values.pgClient.external.host .Values.postgresql.enabled  -}}
 {{- $db := coalesce .Values.postgresql.postgresqlDatabase .Values.pgClient.external.database "hasura" -}}
+{{- $db_options := coalesce .Values.postgresql.options .Values.pgClient.external.options "?sslmode=allow" -}}
 
 {{- $metadata_username := ternary .Values.metadata.username $username .Values.metadata.external  -}}
 {{- $metadata_password := ternary .Values.metadata.password $password .Values.metadata.external  -}}
 {{- $metadata_port := ternary .Values.metadata.port $port .Values.metadata.external  -}}
 {{- $metadata_host := ternary .Values.metadata.host $host .Values.metadata.external  -}}
 {{- $metadata_db := ternary .Values.metadata.database $db .Values.metadata.external  -}}
+{{- $metadata_db_options := ternary .Values.metadata.options $db_options .Values.metadata.external -}}
 
 ---
 apiVersion: v1
@@ -18,5 +20,5 @@ metadata:
 type: Opaque
 data:
   postgresql-password: {{ $password | b64enc | quote }}
-  databaseUrl: {{ (printf "postgres://%s:%s@%s:%d/%s" $username $password $host $port $db) | b64enc | quote }}
-  metadataUrl: {{ (printf "postgres://%s:%s@%s:%d/%s" $metadata_username $metadata_password $metadata_host $metadata_port $metadata_db) | b64enc | quote }}
+  databaseUrl: {{ (printf "postgres://%s:%s@%s:%d/%s%s" $username $password $host $port $db $db_options) | b64enc | quote }}
+  metadataUrl: {{ (printf "postgres://%s:%s@%s:%d/%s%s" $metadata_username $metadata_password $metadata_host $metadata_port $metadata_db $metadata_db_options) | b64enc | quote }}


### PR DESCRIPTION
Hello everyone, 

I added a minor change to support db options for Hasura db and metadata db. This way one can update the connection string and pass the desired options.